### PR TITLE
Changes to make Symplified.Auth work with ADFS IdP

### DIFF
--- a/Symplified.Auth.Android/Symplified.Auth.Android.csproj
+++ b/Symplified.Auth.Android/Symplified.Auth.Android.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{AE33DF0A-7811-43BD-B60E-817CF4BB226A}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{F278D4AB-4730-4720-B08E-FE5E31564D9E};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -35,7 +35,7 @@
     <ConsolePause>false</ConsolePause>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <DefineConstants>PLATFORM_ANDROID;NET_2_0;SECURITY_DEP;MOBILE</DefineConstants>
-    <GenerateDocumentation>true</GenerateDocumentation>
+    <GenerateDocumentation>True</GenerateDocumentation>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -1455,6 +1455,12 @@
     <Compile Include="..\Symplified.Auth\Properties\AssemblyInfo.cs">
       <Link>AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Bindings\HttpRedirectBindingBuilder.cs">
+      <Link>OIOSAML.NET\Bindings\HttpRedirectBindingBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Bindings\HttpRedirectBindingConstants.cs">
+      <Link>OIOSAML.NET\Bindings\HttpRedirectBindingConstants.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -1512,5 +1518,6 @@
     <Folder Include="System.Security.Permissions\" />
     <Folder Include="System.Web\" />
     <Folder Include="OIOSAML.NET\" />
+    <Folder Include="OIOSAML.NET\Bindings\" />
   </ItemGroup>
 </Project>

--- a/Symplified.Auth.iOS/Symplified.Auth.iOS.csproj
+++ b/Symplified.Auth.iOS/Symplified.Auth.iOS.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{842950CE-E49A-4F6D-AC90-FCD5D908175B}</ProjectGuid>
     <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -22,7 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <GenerateDocumentation>true</GenerateDocumentation>
+    <GenerateDocumentation>True</GenerateDocumentation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -70,6 +70,7 @@
     <Folder Include="System\System.Security.Permissions\" />
     <Folder Include="Mono.Xml\" />
     <Folder Include="OIOSAML.NET\Validation\" />
+    <Folder Include="OIOSAML.NET\Bindings\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -253,21 +254,6 @@
     </Compile>
     <Compile Include="..\lib\OIOSAML.NET\Saml20AuthnRequest.cs">
       <Link>OIOSAML.NET\Saml20AuthnRequest.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\OIOSAML.NET\Config\AudienceUris.cs">
-      <Link>OIOSAML.NET\Config\AudienceUris.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\OIOSAML.NET\Config\Certificate.cs">
-      <Link>OIOSAML.NET\Config\Certificate.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\OIOSAML.NET\Config\ConfigurationConstants.cs">
-      <Link>OIOSAML.NET\Config\ConfigurationConstants.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\OIOSAML.NET\Config\ConfigurationReader.cs">
-      <Link>OIOSAML.NET\Config\ConfigurationReader.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\OIOSAML.NET\Config\FederationConfig.cs">
-      <Link>OIOSAML.NET\Config\FederationConfig.cs</Link>
     </Compile>
     <Compile Include="..\lib\OIOSAML.NET\Config\SAML20FederationConfig.cs">
       <Link>OIOSAML.NET\Config\SAML20FederationConfig.cs</Link>
@@ -1319,9 +1305,6 @@
     <Compile Include="..\lib\mono\mcs\class\System\System.Diagnostics\ProcessPriorityClass.cs">
       <Link>System\System.Diagnostics\ProcessPriorityClass.cs</Link>
     </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System\System.Diagnostics\ProcessThreadCollection.cs">
-      <Link>System\System.Diagnostics\ProcessThreadCollection.cs</Link>
-    </Compile>
     <Compile Include="..\lib\mono\mcs\class\System\System.Diagnostics\ProcessWindowStyle.cs">
       <Link>System\System.Diagnostics\ProcessWindowStyle.cs</Link>
     </Compile>
@@ -1504,6 +1487,27 @@
     </Compile>
     <Compile Include="..\Symplified.Auth\Properties\AssemblyInfo.cs">
       <Link>AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Bindings\HttpRedirectBindingBuilder.cs">
+      <Link>OIOSAML.NET\Bindings\HttpRedirectBindingBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Bindings\HttpRedirectBindingConstants.cs">
+      <Link>OIOSAML.NET\Bindings\HttpRedirectBindingConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Config\ConfigurationConstants.cs">
+      <Link>OIOSAML.NET\Config\ConfigurationConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Config\ConfigurationReader.cs">
+      <Link>OIOSAML.NET\Config\ConfigurationReader.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Config\FederationConfig.cs">
+      <Link>OIOSAML.NET\Config\FederationConfig.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Config\Certificate.cs">
+      <Link>OIOSAML.NET\Config\Certificate.cs</Link>
+    </Compile>
+    <Compile Include="..\lib\OIOSAML.NET\Config\AudienceUris.cs">
+      <Link>OIOSAML.NET\Config\AudienceUris.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/Symplified.Auth/Symplified.Auth.csproj
+++ b/Symplified.Auth/Symplified.Auth.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{07F01416-1141-4D72-8A13-BB77DF25E4CE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Symplified.Auth</RootNamespace>
     <AssemblyName>Symplified.Auth</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <ReleaseVersion>1.0</ReleaseVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +22,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <LangVersion>5</LangVersion>
-    <GenerateDocumentation>true</GenerateDocumentation>
+    <DocumentationFile>bin\Debug\Symplified.Auth.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -51,6 +51,9 @@
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\lib\Json.NET\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SAML 1.1\SAML11Authenticator.cs" />
@@ -711,149 +714,11 @@
       <Link>OIOSAML.NET\Validation\Saml20XmlAnyAttributeValidator.cs</Link>
     </Compile>
     <Compile Include="SAML 2.0\SamlAccount.cs" />
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\CipherData.cs">
-      <Link>System.Security.Cryptography.Xml\CipherData.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\CipherReference.cs">
-      <Link>System.Security.Cryptography.Xml\CipherReference.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\DSAKeyValue.cs">
-      <Link>System.Security.Cryptography.Xml\DSAKeyValue.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\DataObject.cs">
-      <Link>System.Security.Cryptography.Xml\DataObject.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\DataReference.cs">
-      <Link>System.Security.Cryptography.Xml\DataReference.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptedData.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptedData.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptedKey.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptedKey.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptedReference.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptedReference.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptedType.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptedType.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptedXml.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptedXml.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptionMethod.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptionMethod.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptionProperties.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptionProperties.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\EncryptionProperty.cs">
-      <Link>System.Security.Cryptography.Xml\EncryptionProperty.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\IRelDecryptor.cs">
-      <Link>System.Security.Cryptography.Xml\IRelDecryptor.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfo.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfoClause.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfoClause.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfoEncryptedKey.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfoEncryptedKey.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfoName.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfoName.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfoNode.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfoNode.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfoRetrievalMethod.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfoRetrievalMethod.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyInfoX509Data.cs">
-      <Link>System.Security.Cryptography.Xml\KeyInfoX509Data.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\KeyReference.cs">
-      <Link>System.Security.Cryptography.Xml\KeyReference.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\Manifest.cs">
-      <Link>System.Security.Cryptography.Xml\Manifest.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\RSAKeyValue.cs">
-      <Link>System.Security.Cryptography.Xml\RSAKeyValue.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\Reference.cs">
-      <Link>System.Security.Cryptography.Xml\Reference.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\ReferenceList.cs">
-      <Link>System.Security.Cryptography.Xml\ReferenceList.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\Signature.cs">
-      <Link>System.Security.Cryptography.Xml\Signature.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\SignedInfo.cs">
-      <Link>System.Security.Cryptography.Xml\SignedInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\SignedXml.cs">
-      <Link>System.Security.Cryptography.Xml\SignedXml.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\SymmetricKeyWrap.cs">
-      <Link>System.Security.Cryptography.Xml\SymmetricKeyWrap.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\Transform.cs">
-      <Link>System.Security.Cryptography.Xml\Transform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\TransformChain.cs">
-      <Link>System.Security.Cryptography.Xml\TransformChain.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\X509IssuerSerial.cs">
-      <Link>System.Security.Cryptography.Xml\X509IssuerSerial.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDecryptionTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDecryptionTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigBase64Transform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigBase64Transform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigC14NTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigC14NTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigC14NWithCommentsTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigC14NWithCommentsTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigEnvelopedSignatureTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigEnvelopedSignatureTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigExcC14NTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigExcC14NTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigExcC14NWithCommentsTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigExcC14NWithCommentsTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigNodeList.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigNodeList.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigXPathTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigXPathTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlDsigXsltTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlDsigXsltTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlEncryption.cs">
-      <Link>System.Security.Cryptography.Xml\XmlEncryption.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlLicenseTransform.cs">
-      <Link>System.Security.Cryptography.Xml\XmlLicenseTransform.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlSignature.cs">
-      <Link>System.Security.Cryptography.Xml\XmlSignature.cs</Link>
-    </Compile>
-    <Compile Include="..\lib\mono\mcs\class\System.Security\System.Security.Cryptography.Xml\XmlSignatureStreamReader.cs">
-      <Link>System.Security.Cryptography.Xml\XmlSignatureStreamReader.cs</Link>
-    </Compile>
     <Compile Include="SAML 2.0\Saml20Authenticator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\lib\mono\mcs\class\System\System.Diagnostics\ProcessThreadCollection.cs">
+      <Link>OIOSAML.NET\ProcessThreadCollection.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -861,7 +726,6 @@
     <Folder Include="SAML 2.0\" />
     <Folder Include="Symplified AuthN\" />
     <Folder Include="OIOSAML.NET\" />
-    <Folder Include="System.Security.Cryptography.Xml\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\lib\Xamarin.Auth\src\Xamarin.Auth\Xamarin.Auth.csproj">

--- a/Symplified.Auth/packages.config
+++ b/Symplified.Auth/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
+</packages>

--- a/lib/OIOSAML.NET/Config/ConfigurationReader.cs
+++ b/lib/OIOSAML.NET/Config/ConfigurationReader.cs
@@ -20,7 +20,12 @@ namespace dk.nita.saml20.config
         /// <param name="reader">The <see cref="T:System.Xml.XmlReader"/> that reads from the configuration file.</param>
         /// <param name="serializeCollectionKey">true to serialize only the collection key properties; otherwise, false.</param>
         /// <exception cref="T:System.Configuration.ConfigurationErrorsException">The element to read is locked.- or -An attribute of the current node is not recognized.- or -The lock status of the current node cannot be determined.  </exception>
-		public override void DeserializeElement(XmlReader reader, bool serializeCollectionKey)
+#if MOBILE
+		public
+#else
+		protected
+#endif
+		override void DeserializeElement(XmlReader reader, bool serializeCollectionKey)
         {
             XmlSerializer serializer = new XmlSerializer(_currentConfigType);
             _currentConfig = serializer.Deserialize(reader);
@@ -30,7 +35,12 @@ namespace dk.nita.saml20.config
         /// Retrieves the contained object from the section.
         /// </summary>
         /// <returns>The contained data object.</returns>
-        public override object GetRuntimeObject()
+#if MOBILE
+		public
+#else
+		protected
+#endif
+		override object GetRuntimeObject()
         {
             return _currentConfig;
         }
@@ -106,7 +116,12 @@ namespace dk.nita.saml20.config
         /// <param name="name">The name of the section.</param>
         /// <param name="saveMode">The mode to use when saving.</param>
         /// <returns></returns>
-		public override string SerializeSection(ConfigurationElement parentElement, string name, ConfigurationSaveMode saveMode)
+#if MOBILE
+		public
+#else
+		protected
+#endif
+		override string SerializeSection(ConfigurationElement parentElement, string name, ConfigurationSaveMode saveMode)
         {
             StringBuilder str = new StringBuilder();
             XmlWriterSettings settings = new XmlWriterSettings();

--- a/lib/OIOSAML.NET/Logging/AuditLogging.cs
+++ b/lib/OIOSAML.NET/Logging/AuditLogging.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-//using System.Web;
+using System.Web;
 using System.Xml;
-//using dk.nita.saml20.identity;
+using dk.nita.saml20.identity;
 using dk.nita.saml20.Schema.Metadata;
 using log4net;
 using log4net.Repository.Hierarchy;

--- a/lib/OIOSAML.NET/Protocol/Saml20SignonHandler.cs
+++ b/lib/OIOSAML.NET/Protocol/Saml20SignonHandler.cs
@@ -200,7 +200,7 @@ namespace dk.nita.saml20.protocol
                 return;
             }
 
-            Saml20AuthnRequest authnRequest = Saml20AuthnRequest.GetDefault();
+			var authnRequest = Saml20AuthnRequest.GetDefault (idpEndpoint.Name);
             TransferClient(idpEndpoint, authnRequest, context);            
         }
 

--- a/lib/OIOSAML.NET/Saml20ArtifactResolve.cs
+++ b/lib/OIOSAML.NET/Saml20ArtifactResolve.cs
@@ -6,6 +6,7 @@ using dk.nita.saml20.Schema.Core;
 using dk.nita.saml20.Schema.Protocol;
 using dk.nita.saml20.Utils;
 using Saml2.Properties;
+using dk.nita.saml20.config;
 
 namespace dk.nita.saml20
 {

--- a/lib/OIOSAML.NET/Saml20ArtifactResponse.cs
+++ b/lib/OIOSAML.NET/Saml20ArtifactResponse.cs
@@ -6,6 +6,7 @@ using dk.nita.saml20.Schema.Core;
 using dk.nita.saml20.Schema.Protocol;
 using dk.nita.saml20.Utils;
 using Saml2.Properties;
+using dk.nita.saml20.config;
 
 namespace dk.nita.saml20
 {

--- a/lib/OIOSAML.NET/Saml20Assertion.cs
+++ b/lib/OIOSAML.NET/Saml20Assertion.cs
@@ -405,7 +405,7 @@ namespace dk.nita.saml20
 			// FIXME: This code was changed to *not* use UTC
 			// for date comparisons, because UTC date conversion
 			// is non-functional on Xamarin.
-			return (DateTime.Now.CompareTo (NotOnOrAfter) > 0);
+			return (DateTime.UtcNow.CompareTo (NotOnOrAfter) > 0);
         }
 
         /// <summary>

--- a/samples/Symplified.Auth.Android.Sample/Symplified.Auth.Android.Sample.csproj
+++ b/samples/Symplified.Auth.Android.Sample/Symplified.Auth.Android.Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{CFE86511-190A-461C-82C4-053064F6E555}</ProjectGuid>
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{F278D4AB-4730-4720-B08E-FE5E31564D9E};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -50,9 +50,6 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Mono.Android.Export" />
-    <Reference Include="Symplified.Auth.Android">
-      <HintPath>lib\Symplified.Auth.Android.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Auth.Android">
       <HintPath>lib\Xamarin.Auth.Android.dll</HintPath>
     </Reference>
@@ -81,5 +78,11 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\idp.symplified.net.metadata.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Symplified.Auth.Android\Symplified.Auth.Android.csproj">
+      <Project>{AE33DF0A-7811-43BD-B60E-817CF4BB226A}</Project>
+      <Name>Symplified.Auth.Android</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/samples/Symplified.Auth.iOS.Sample/Symplified.Auth.iOS.Sample.csproj
+++ b/samples/Symplified.Auth.iOS.Sample/Symplified.Auth.iOS.Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{9FC99112-BA74-4A89-8285-A31D612925CA}</ProjectGuid>
     <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -24,7 +24,8 @@
     <ConsolePause>false</ConsolePause>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchI18n />
+    <MtouchI18n>
+    </MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchSdkVersion>6.1</MtouchSdkVersion>
   </PropertyGroup>
@@ -36,7 +37,8 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchLink>None</MtouchLink>
-    <MtouchI18n />
+    <MtouchI18n>
+    </MtouchI18n>
     <MtouchArch>ARMv7</MtouchArch>
     <MtouchSdkVersion>6.1</MtouchSdkVersion>
   </PropertyGroup>
@@ -53,7 +55,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchSdkVersion>6.1</MtouchSdkVersion>
     <MtouchLink>None</MtouchLink>
-    <MtouchI18n />
+    <MtouchI18n>
+    </MtouchI18n>
     <MtouchArch>ARMv7, ARMv7s</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
@@ -64,9 +67,11 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchSdkVersion>6.1</MtouchSdkVersion>
-    <IpaPackageName />
+    <IpaPackageName>
+    </IpaPackageName>
     <MtouchLink>None</MtouchLink>
-    <MtouchI18n />
+    <MtouchI18n>
+    </MtouchI18n>
     <MtouchArch>ARMv7, ARMv7s</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
@@ -103,12 +108,6 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>lib\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Symplified.Auth.iOS">
-      <HintPath>lib\Symplified.Auth.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Auth.iOS">
-      <HintPath>lib\Xamarin.Auth.iOS.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -124,5 +123,15 @@
   <ItemGroup>
     <Content Include="idp.symplified.net.metadata.xml" />
     <Content Include="salesforce-oauthsaml2-idp-metadata.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Symplified.Auth.iOS\Symplified.Auth.iOS.csproj">
+      <Project>{842950CE-E49A-4F6D-AC90-FCD5D908175B}</Project>
+      <Name>Symplified.Auth.iOS</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\lib\Xamarin.Auth\src\Xamarin.Auth.iOS\Xamarin.Auth.iOS.csproj">
+      <Project>{9309BCCC-AA7B-4195-A130-D4572FA9488D}</Project>
+      <Name>Xamarin.Auth.iOS</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The most important change is in the Saml20Authenticator, which uses Deflate + Base64 encoding for the SAML AuthnRequest (http://en.wikipedia.org/wiki/SAML_2.0#SAML_2.0_Bindings) so that integration with ADFS works as expected. Using only a Base64Encoded AuthnRequest results in error MSIS7015 in ADFS, meaning that there was no valid SAML AuthnRequest found.

Also fixed CheckValid for Saml20Assertion to use UtcNow because it would fail with “Assertion no longer valid”.

Needed to make some changes to the OIOSAML.NET source code compiles with Xamarin.
